### PR TITLE
fix(generate): trim prefix slash in path

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/iancoleman/orderedmap"
 )
@@ -47,7 +48,7 @@ func (e *endpoints) generate(filename string) error {
 			Path string `json:"path"`
 			Desc string `json:"desc"`
 		}{
-			Path: v.Path,
+			Path: strings.TrimPrefix(v.Path, "/"),
 			Desc: v.Desc,
 		})
 	}


### PR DESCRIPTION
Why

pathの先頭に"/"を付けてはいけない仕様なのに付けてしまっていた

What

先頭に/を付けないように修正