### PR TITLE
feat(wrapper): implement GroupWithVersionsAndFrontends

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ articles.POST("/", articleHandler.CreateArticle, endpoints.Desc{
     Desc: "記事を新規作成する",
 })
 
+// グループ単位でVersionsやFrontendsを指定することもできる
+comments := ew.GroupWithVersionsAndFrontends(
+    "/comments",
+    []string{"v2"},
+    []string{"manager"},
+)
+// このエンドポイントは"v2", "manager-v2"のみに含まれる
+comments.POST("/", commentHandler.CreateComment, endpoints.Desc{
+	Name: "createComment",
+    Query: "",
+    Desc: "コメントを新規作成する",
+})
+
 // .endpoints.jsonファイルの出力
 if err := ew.Generate(".endpoints.json"); err != nil {
     log.Printf("failed to generate endpoints file: %v", err)


### PR DESCRIPTION
## Why
Closes #6 Group単位でVersionsとFrontendsを指定できるようにする

少なくともSumycaは呼び出し元のフロントごとにpathを分けているので、個別のエンドポイントごとに指定を行うのは面倒なことに気付いたので