### PR TITLE
chore(*): change first argument of generateOpenApi io.Writer

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -238,7 +238,7 @@ func (e *endpoints) generateOpenApiSchema(config OpenApiGeneratorConfig) (openap
 	return schema, nil
 }
 
-func (e *endpoints) generateOpenApiJson(filename string, config OpenApiGeneratorConfig) error {
+func (e *endpoints) generateOpenApiJson(file io.Writer, config OpenApiGeneratorConfig) error {
 	schema, err := e.generateOpenApiSchema(config)
 	if err != nil {
 		return err
@@ -249,14 +249,14 @@ func (e *endpoints) generateOpenApiJson(filename string, config OpenApiGenerator
 		return err
 	}
 
-	if err := os.WriteFile(filename, bs, 0644); err != nil {
+	if _, err := file.Write(bs); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (e *endpoints) generateOpenApiYaml(filename string, config OpenApiGeneratorConfig) error {
+func (e *endpoints) generateOpenApiYaml(file io.Writer, config OpenApiGeneratorConfig) error {
 	schema, err := e.generateOpenApiSchema(config)
 	if err != nil {
 		return err
@@ -278,7 +278,7 @@ func (e *endpoints) generateOpenApiYaml(filename string, config OpenApiGenerator
 		return err
 	}
 
-	if err := os.WriteFile(filename, bs, 0644); err != nil {
+	if _, err := file.Write(bs); err != nil {
 		return err
 	}
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,6 +1,9 @@
 package endpoints
 
-import "github.com/labstack/echo/v4"
+import (
+	"github.com/labstack/echo/v4"
+	"os"
+)
 
 // EchoWrapper に対応するメソッドが存在しないEchoの機能を使いたい場合に限り、
 // wrapされたEchoを直接呼んでよい。
@@ -58,11 +61,26 @@ func (w *EchoWrapper) Generate(filename string) error {
 }
 
 func (w *EchoWrapper) GenerateOpenApiJson(filename string, config OpenApiGeneratorConfig) error {
-	return w.endpoints.generateOpenApiJson(filename, config)
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		file.Close()
+	}()
+
+	return w.endpoints.generateOpenApiJson(file, config)
 }
 
 func (w *EchoWrapper) GenerateOpenApi(filename string, config OpenApiGeneratorConfig) error {
-	return w.endpoints.generateOpenApiYaml(filename, config)
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		file.Close()
+	}()
+	return w.endpoints.generateOpenApiYaml(file, config)
 }
 
 func (w *EchoWrapper) GET(path string, h echo.HandlerFunc, desc Desc, m ...echo.MiddlewareFunc) *echo.Route {


### PR DESCRIPTION
# why

endpoints.generateOpenApi の第一引数はWriterであれば十分である。

GenerateOpenApiは、filenameを受け取ったら、それをos.Fileにして渡す。

Closes: #20