### PR TITLE
chore(renovate): add renovate label to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "addLabels": ["renovate"],
   "timezone": "Asia/Tokyo",
   "extends": [
     "config:recommended",


### PR DESCRIPTION
## 概要

Renovate が作成する PR に `renovate` ラベルを一律付与するため、`renovate.json` のトップレベルに `addLabels: ["renovate"]` を追加します。

## なぜ `labels` ではなく `addLabels` か

- `labels` は非マージ（置換）フィールドのため、既存の `labels`（例: `dependencies`）や `vulnerabilityAlerts.labels`（例: `security`）を上書きしてしまいます。
- `addLabels` はマージ可能（追記型）で、既存ラベルを保持したまま全 PR（通常の依存更新・グルーピング・脆弱性アラート）に `renovate` を追記できます。

## ラベルの事前作成は不要（検証済み）

リポジトリに `renovate` ラベルが未登録でも問題ありません。GitHub のラベル追加 API は、未登録のラベル名を渡すと**エラーにせず自動生成**します。以下で実証済みです。

1. **GitHub API の実挙動**: 存在しないラベル名を `POST /repos/{owner}/{repo}/issues/{n}/labels` で付与すると、エラーにならずラベルが自動生成される（初回はデフォルト色のグレー `#ededed`）ことを実測で確認。
2. **Renovate bot 自身での実績**: 同 org の `m2m-cleaning-cleaner-front` PR #587 のイベントログに `actor: renovate[bot]` が `renovate` ラベルを付与した記録があり、その `renovate` ラベルは現在も `color: ededed` / `description: null`（＝API による自動生成の痕跡）。Renovate の bot トークンでも未登録ラベルの自動生成付与に成功していることを確認済み。

したがって事前のラベル作成は不要です。色や説明を整えたい場合のみ、後から `renovate` ラベルを編集してください。

## 影響範囲

- `renovate.json` の設定変更のみ。依存パッケージの更新は含みません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
