### PR TITLE
ci(release): リリースPR作成をreusable workflowに置き換え、低リスクリリースの自動マージを追加

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   create-release-pr:
-    uses: matsuri-tech/matsuri-workflows/.github/workflows/create-release-pr.yml@main
+    uses: matsuri-tech/matsuri-workflows/.github/workflows/create-release-pr.yml@a293e3fcbaef01ef4a6e7f4289d288854944eed6  # PR#170 (2026-08-21)
     with:
+      base_branch: master
       version_manager: version-file
     secrets:
       REPO_ONLY_GITHUB_TOKEN: ${{ secrets.REPO_ONLY_GITHUB_TOKEN }}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -6,90 +6,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-commits:
-    runs-on: ubuntu-latest
-    outputs:
-      has_new_commits: ${{ steps.check.outputs.has_new_commits }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check for new commits
-        id: check
-        run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          COMMIT_COUNT=$(git rev-list $LAST_TAG..HEAD --count)
-          echo "has_new_commits=$([ $COMMIT_COUNT -gt 0 ] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
-          echo "No new commits since last tag ($LAST_TAG). Skipping release PR creation."
-
   create-release-pr:
-    needs: check-commits
-    if: needs.check-commits.outputs.has_new_commits == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get current version
-        id: version
-        run: |
-          CURRENT_VERSION=$(cat .version)
-          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Determine next version
-        id: next_version
-        run: |
-          CURRENT_VERSION=$(cat .version)
-          IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-
-          # 前回のタグ以降のコミットを取得
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          COMMITS=$(git log $LAST_TAG..HEAD --pretty=format:"%s")
-
-          # バージョンアップの種類を判定
-          VERSION_BUMP="patch"
-
-          while IFS= read -r commit; do
-            # BREAKING CHANGE または feat! で始まるコミットがあればメジャーバージョンアップ
-            if [[ $commit =~ ^(feat!|.*BREAKING CHANGE:) ]]; then
-              VERSION_BUMP="major"
-              break
-            # feat: で始まるコミットがあればマイナーバージョンアップ
-            elif [[ $commit =~ ^feat: ]] && [ "$VERSION_BUMP" != "major" ]; then
-              VERSION_BUMP="minor"
-            fi
-          done <<< "$COMMITS"
-
-          # バージョンを更新
-          case $VERSION_BUMP in
-            "major")
-              NEXT_VERSION="$((major + 1)).0.0"
-              ;;
-            "minor")
-              NEXT_VERSION="$major.$((minor + 1)).0"
-              ;;
-            "patch")
-              NEXT_VERSION="$major.$minor.$((patch + 1))"
-              ;;
-          esac
-
-          echo "version_bump=$VERSION_BUMP" >> $GITHUB_OUTPUT
-          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Update version file
-        run: |
-          echo "${{ steps.next_version.outputs.next_version }}" > .version
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: bump version to ${{ steps.next_version.outputs.next_version }}"
-          title: "Release Note: v${{ steps.next_version.outputs.next_version }}"
-          branch: release/v${{ steps.next_version.outputs.next_version }}
-          base: master
-          reviewers: hrdtbs
-          labels: release
-          delete-branch: true
+    uses: matsuri-tech/matsuri-workflows/.github/workflows/create-release-pr.yml@main
+    with:
+      version_manager: version-file
+    secrets:
+      REPO_ONLY_GITHUB_TOKEN: ${{ secrets.REPO_ONLY_GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

リリースPR運用の改善([matsuri-workflows#169](https://github.com/matsuri-tech/matsuri-workflows/pull/169))をこのリポジトリに適用します。

**依存**: matsuri-workflows#169 が先にマージされている必要があります(本PRを先にマージした場合も、火曜のcron実行が失敗するだけで実害はありません)。

## 変更内容

- `create-release-pr.yml` を matsuri-workflows の reusable workflow 呼び出しに置き換え
  - リリース要否判定: 公開物に影響するコミット(`ci:` / `docs:` / `test:` / depsを除く `chore:` 以外)がある場合のみPRを作成
  - リリース内容が依存関係のminor/patch更新のみの場合、`auto-release` ラベルを付与しauto-mergeを有効化(CI通過で自動リリース)。それ以外は従来どおりレビュー待ち
  - リリースPRに `hold` ラベルを付けるとauto-mergeを抑止(緊急停止用)
  - bump判定のバグ修正(`feat(scope):` がpatch扱いになる、footerの `BREAKING CHANGE:` を検出できない等)

- タグ作成は既存の `create-tag.yml` をそのまま利用します

## 有効化に必要な設定(別途実施)

- `REPO_ONLY_GITHUB_TOKEN` シークレットの追加(従来は `GITHUB_TOKEN` でPRを作成していたため、リリースPR上でCIがトリガーされない問題がありました)
- branch protection に required status checks(test, lint)を設定
- branch protection の bypass_pull_request_allowances に matsuri-ci を追加
